### PR TITLE
Add per-project duration gauge and update build duration metric

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -133,11 +133,14 @@ def build_duration_seconds(build):
     Returns:
         int: Number of seconds between finish and start timestamps.
     """
-    fmt = "%Y%m%dT%H%M%S%z"
-    start = datetime.strptime(build['startDate'], fmt)
-    finish = datetime.strptime(build['finishDate'], fmt)
-    if start == '' or finish == '':
+    start_raw = build['startDate']
+    finish_raw = build['finishDate']
+    if start_raw == '' or finish_raw == '':
         return None
+    fmt = "%Y%m%dT%H%M%S%z"
+    start = datetime.strptime(start_raw, fmt)
+    finish = datetime.strptime(finish_raw, fmt)
+
     delta = finish - start
     return int(delta.total_seconds())
 

--- a/app/main.py
+++ b/app/main.py
@@ -101,9 +101,10 @@ def get_project_url(projectid):
 
 def fetch_and_update_metrics():
     logging.debug("Reached fetch_and_update_metrics")
-    all_projects = {}
+
     while True:
         archived_projects = get_archived_projects()
+        all_projects = {}
         try:
             for template_id in TEMPLATE_IDS:
                 build_configs = get_build_configs_from_template(template_id)

--- a/app/main.py
+++ b/app/main.py
@@ -143,7 +143,7 @@ def fetch_and_update_metrics():
                     projectId=k,
                     project_url=v["project_url"],
                     project_name=v["project_name"]
-                ).set(v['duration'])
+                ).set(v['project_duration'])
         except Exception as e:
 
             logging.debug(f"Obtaining [ERROR] {e}")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added project-level duration metric aggregating last successful build durations per project with projectId, project URL, and project name labels.
  - Added helper APIs to fetch build configs, archived projects, last build status, build duration, and project URLs.

- Changes
  - Switched build-duration reporting to a gauge for last successful builds; labels and descriptions updated.
  - Per-template build status emission preserved within an updated processing loop.

- Chores
  - Archived projects skipped each collection cycle; per-project data initialized and refreshed per cycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->