### PR TITLE
Add finish date

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ teamcity_last_build_status{
   build_type_id="<< ID of the build being checked >>",
   build_type_name="<< name of the specific build >>",
   build_url="<< build URL >>"
+  finish_date=finish_date,
+  start_date=start_date
 } << build result >>
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ teamcity_last_build_status{
   build_type_id="<< ID of the build being checked >>",
   build_type_name="<< name of the specific build >>",
   build_url="<< build URL >>"
-  finish_date=finish_date,
-  start_date=start_date
+  finish_date="<< build finish date >>",
+  start_date="<< build start date >>"
 } << build result >>
 ```
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,8 +4,7 @@ import requests
 import threading
 from prometheus_client import start_http_server, Gauge, Summary
 import logging
-from datetime import datetime
-import json
+from datetime import datetime, timezone
 
 
 def get_log_level():
@@ -353,6 +352,10 @@ def update_jdk_metrics():
     except Exception as e:
         logging.error(f"Error updating JDK metrics: {e}")
 
+def convert_time(dt_str=""):
+    dt = datetime.strptime(dt_str, "%Y%m%dT%H%M%S%z")
+    return int(dt.timestamp())
+
 
 def update_build_status_metrics():
     """
@@ -374,12 +377,8 @@ def update_build_status_metrics():
                 last_build = get_last_build_status(cfg["id"])
                 status = last_build['status']
                 status_value = {"SUCCESS": 1, "FAILURE": 0, "NO_BUILDS": -1}.get(status, -1)
-                if status == "NO_BUILDS":
-                    finish_date = 0
-                    start_date = 0
-                else:
-                    finish_date = last_build['finishDate']
-                    start_date = last_build['startDate']
+                finish_date = convert_time(last_build.get('finishDate', '')) if status != "NO_BUILDS" else 0
+                start_date = convert_time(last_build.get('startDate', '')) if status != "NO_BUILDS" else 0
                 BUILD_STATUS_GAUGE.labels(
                     template_id=template_id,
                     build_type_name=cfg["name"],
@@ -439,12 +438,8 @@ def fetch_and_update_full_metrics():
                             build_type_id=cfg["id"],
                             build_url=cfg["webUrl"]).set(duration)
 
-                    if status == "NO_BUILDS":
-                        finish_date = 0
-                        start_date = 0
-                    else:
-                        finish_date = last_build['finishDate']
-                        start_date = last_build['startDate']
+                    finish_date = convert_time(last_build.get('finishDate', '')) if status != "NO_BUILDS" else 0
+                    start_date = convert_time(last_build.get('startDate', '')) if status != "NO_BUILDS" else 0
                     BUILD_STATUS_GAUGE.labels(
                         template_id=template_id,
                         build_type_name=cfg["name"],

--- a/app/main.py
+++ b/app/main.py
@@ -53,7 +53,7 @@ HEADERS = {
 BUILD_STATUS_GAUGE = Gauge(
     "teamcity_last_build_status",
     "Last build status for build configurations from a template",
-    ["build_type_name", "template_id", "build_type_id", "build_url"]
+    ["build_type_name", "template_id", "build_type_id", "build_url","finish_date"]
 )
 
 BUILD_DURATION_GAUGE = Gauge(
@@ -379,7 +379,8 @@ def update_build_status_metrics():
                     template_id=template_id,
                     build_type_name=cfg["name"],
                     build_type_id=cfg["id"],
-                    build_url=cfg["webUrl"]
+                    build_url=cfg["webUrl"],
+                    finish_date=cfg['finishDate']
                 ).set(status_value)
 
         logging.info(f"Build status metrics updated successfully")
@@ -436,7 +437,8 @@ def fetch_and_update_full_metrics():
                         template_id=template_id,
                         build_type_name=cfg["name"],
                         build_type_id=cfg["id"],
-                        build_url=cfg["webUrl"]
+                        build_url=cfg["webUrl"],
+                        finish_date=cfg['finishDate']
                     ).set(status_value)
 
             for k, v in all_projects.items():

--- a/app/main.py
+++ b/app/main.py
@@ -53,7 +53,7 @@ HEADERS = {
 BUILD_STATUS_GAUGE = Gauge(
     "teamcity_last_build_status",
     "Last build status for build configurations from a template",
-    ["build_type_name", "template_id", "build_type_id", "build_url","finish_date"]
+    ["build_type_name", "template_id", "build_type_id", "build_url", "finish_date", "start_date"]
 )
 
 BUILD_DURATION_GAUGE = Gauge(
@@ -380,7 +380,8 @@ def update_build_status_metrics():
                     build_type_name=cfg["name"],
                     build_type_id=cfg["id"],
                     build_url=cfg["webUrl"],
-                    finish_date=cfg['finishDate']
+                    finish_date=last_build['finishDate'],
+                    start_date=last_build['startDate']
                 ).set(status_value)
 
         logging.info(f"Build status metrics updated successfully")
@@ -438,7 +439,8 @@ def fetch_and_update_full_metrics():
                         build_type_name=cfg["name"],
                         build_type_id=cfg["id"],
                         build_url=cfg["webUrl"],
-                        finish_date=cfg['finishDate']
+                        finish_date=last_build['finishDate'],
+                        start_date=last_build['startDate']
                     ).set(status_value)
 
             for k, v in all_projects.items():

--- a/app/main.py
+++ b/app/main.py
@@ -353,6 +353,8 @@ def update_jdk_metrics():
         logging.error(f"Error updating JDK metrics: {e}")
 
 def convert_time(dt_str=""):
+    if not dt_str:
+        return 0
     dt = datetime.strptime(dt_str, "%Y%m%dT%H%M%S%z")
     return int(dt.timestamp())
 

--- a/app/main.py
+++ b/app/main.py
@@ -392,7 +392,6 @@ def update_build_status_metrics():
         logging.info(f"Build status metrics updated successfully")
 
     except Exception as e:
-        logging.info(f"{status} - {status_value}")
         logging.error(f"Error updating build status metrics: {e}")
 
 
@@ -500,8 +499,8 @@ if __name__ == "__main__":
     logging.info(f"Full metrics interval: {SCRAPE_INTERVAL} seconds")
 
     # Start thread for full metrics (JDK, durations, projects, status)
-    #full_metrics_thread = threading.Thread(target=fetch_and_update_full_metrics, daemon=True)
-    #full_metrics_thread.start()
+    full_metrics_thread = threading.Thread(target=fetch_and_update_full_metrics, daemon=True)
+    full_metrics_thread.start()
 
     # Start thread for fast status updates only
     status_metrics_thread = threading.Thread(target=fetch_and_update_status_metrics, daemon=True)

--- a/app/main.py
+++ b/app/main.py
@@ -359,8 +359,12 @@ def convert_time(dt_str=""):
 
 def update_build_status_metrics():
     """
-    Update only BUILD_STATUS_GAUGE metrics for all build configurations from configured templates.
-    This function runs more frequently to provide faster status updates.
+    Update BUILD_STATUS_GAUGE for all build configurations derived from the configured templates.
+    
+    For each non-archived build configuration this function sets BUILD_STATUS_GAUGE with labels
+    (template_id, build_type_name, build_type_id, build_url, finish_date, start_date).
+    Value semantics: `1` for SUCCESS, `0` for FAILURE, `-1` for NO_BUILDS or unknown status.
+    Skip build configurations belonging to archived projects.
     """
     logging.info("Updating build status metrics")
 
@@ -396,12 +400,12 @@ def update_build_status_metrics():
 
 def fetch_and_update_full_metrics():
     """
-    Continuously poll TeamCity and refresh ALL Prometheus gauges for builds, projects, and JDK distribution.
-
-    On each interval it retrieves build configurations for the configured templates, skips archived projects,
-    records the latest build status and successful build durations, aggregates project durations for finished
-    project chains, and updates JDK-related metrics; this function runs indefinitely and sleeps SCRAPE_INTERVAL
-    between iterations.
+    Continuously poll TeamCity and refresh all Prometheus gauges for builds, projects, and JDK distribution.
+    
+    This function runs indefinitely: on each iteration it updates JDK-related metrics, iterates configured templates to
+    collect non-archived build configurations, records latest build status and successful build durations, aggregates
+    project-chain durations for templates in the stop-project chain, and updates project-level duration metrics.
+    It skips archived projects and pauses SCRAPE_INTERVAL seconds between iterations.
     """
     logging.info("Starting full metrics update thread")
 

--- a/app/main.py
+++ b/app/main.py
@@ -374,19 +374,25 @@ def update_build_status_metrics():
                 last_build = get_last_build_status(cfg["id"])
                 status = last_build['status']
                 status_value = {"SUCCESS": 1, "FAILURE": 0, "NO_BUILDS": -1}.get(status, -1)
-
+                if status == "NO_BUILDS":
+                    finish_date = 0
+                    start_date = 0
+                else:
+                    finish_date = last_build['finishDate']
+                    start_date = last_build['startDate']
                 BUILD_STATUS_GAUGE.labels(
                     template_id=template_id,
                     build_type_name=cfg["name"],
                     build_type_id=cfg["id"],
                     build_url=cfg["webUrl"],
-                    finish_date=last_build['finishDate'],
-                    start_date=last_build['startDate']
+                    finish_date=finish_date,
+                    start_date=start_date
                 ).set(status_value)
 
         logging.info(f"Build status metrics updated successfully")
 
     except Exception as e:
+        logging.info(f"{status} - {status_value}")
         logging.error(f"Error updating build status metrics: {e}")
 
 
@@ -434,15 +440,20 @@ def fetch_and_update_full_metrics():
                             build_type_id=cfg["id"],
                             build_url=cfg["webUrl"]).set(duration)
 
+                    if status == "NO_BUILDS":
+                        finish_date = 0
+                        start_date = 0
+                    else:
+                        finish_date = last_build['finishDate']
+                        start_date = last_build['startDate']
                     BUILD_STATUS_GAUGE.labels(
                         template_id=template_id,
                         build_type_name=cfg["name"],
                         build_type_id=cfg["id"],
                         build_url=cfg["webUrl"],
-                        finish_date=last_build['finishDate'],
-                        start_date=last_build['startDate']
+                        finish_date=finish_date,
+                        start_date=start_date
                     ).set(status_value)
-
             for k, v in all_projects.items():
                 if v['startDate']:
                     full_duration = build_duration_seconds(v)
@@ -489,8 +500,8 @@ if __name__ == "__main__":
     logging.info(f"Full metrics interval: {SCRAPE_INTERVAL} seconds")
 
     # Start thread for full metrics (JDK, durations, projects, status)
-    full_metrics_thread = threading.Thread(target=fetch_and_update_full_metrics, daemon=True)
-    full_metrics_thread.start()
+    #full_metrics_thread = threading.Thread(target=fetch_and_update_full_metrics, daemon=True)
+    #full_metrics_thread.start()
 
     # Start thread for fast status updates only
     status_metrics_thread = threading.Thread(target=fetch_and_update_status_metrics, daemon=True)

--- a/app/main.py
+++ b/app/main.py
@@ -353,11 +353,12 @@ def update_jdk_metrics():
         logging.error(f"Error updating JDK metrics: {e}")
 
 def convert_time(dt_str=""):
-    if not dt_str:
+    try:
+        dt = datetime.strptime(dt_str, "%Y%m%dT%H%M%S%z")
+        return int(dt.timestamp())
+    except (ValueError, TypeError):
+        logging.warning(f"Failed to parse timestamp: {dt_str!r}")
         return 0
-    dt = datetime.strptime(dt_str, "%Y%m%dT%H%M%S%z")
-    return int(dt.timestamp())
-
 
 def update_build_status_metrics():
     """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prometheus build status metrics now include two new timing labels — finish_date and start_date — so dashboards and alerts can show exact build start and finish times for better lifecycle analysis and troubleshooting.
  * When no builds exist, those labels report as zero to ensure consistent metric behavior and reliable missing-data detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->